### PR TITLE
Update readthedocs config

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -5,9 +5,10 @@
 # Required
 version: 2
 
-# Add libsndfile to the image
 build:
-  image: latest
+  os: ubuntu-22.04
+  tools:
+    python: "3.10"
   apt_packages:
     - libsndfile1
 
@@ -21,6 +22,5 @@ formats:
 
 # Optionally set the version of Python and requirements required to build your docs
 python:
-  version: 3.7
   install:
     - requirements: requirements_dev.txt


### PR DESCRIPTION
Update the config to new format.
- `os` is now required.
- python version definition has been moved to `build` section

closes #20 