### PR TITLE
remove squeeze from dsp

### DIFF
--- a/pyrato/dsp.py
+++ b/pyrato/dsp.py
@@ -145,7 +145,7 @@ def find_impulse_response_maximum(
             "The SNR seems lower than the specified threshold value. Check "
             "if this is a valid impulse response with sufficient SNR.")
 
-    return np.squeeze(max_sample)
+    return max_sample
 
 
 def time_shift(signal, shift, circular_shift=True, unit='samples'):


### PR DESCRIPTION
Remove squeeze from `dsp.find_impulse_response_maximum()` to match updated behavior in pyfar.