### PR TITLE
add T15

### DIFF
--- a/pyrato/rap.py
+++ b/pyrato/rap.py
@@ -17,7 +17,7 @@ def reverberation_time_linear_regression(
         Energy decay curve. The time needs to be the arrays last dimension.
     times : ndarray, double
         Time vector corresponding to each sample of the EDC.
-    T : 'T20', 'T30', 'T40', 'T50', 'T60', 'EDT', 'LDT'
+    T : 'T15', 'T20', 'T30', 'T40', 'T50', 'T60', 'EDT', 'LDT'
         Decay interval to be used for the reverberation time extrapolation. EDT
         corresponds to the early decay time extrapolated from the interval
         ``[0, -10]`` dB, LDT corresponds to the late decay time extrapolated
@@ -65,7 +65,7 @@ def reverberation_time_linear_regression(
     ...     array([0.99526253])
 
     """
-    intervals = [20, 30, 40, 50, 60]
+    intervals = [15, 20, 30, 40, 50, 60]
 
     if T == 'EDT':
         upper = -0.1

--- a/tests/test_rt.py
+++ b/tests/test_rt.py
@@ -13,7 +13,7 @@ import pytest
 
 
 @pytest.mark.parametrize(
-    'tx', ['T20', 'T30', 'T40', 'T50', 'T60', 'LDT', 'EDT'])
+    'tx', ['T15', 'T20', 'T30', 'T40', 'T50', 'T60', 'LDT', 'EDT'])
 def test_rt_from_edc(tx):
     times = np.linspace(0, 1.5, 2**9)
     m = -60
@@ -25,7 +25,7 @@ def test_rt_from_edc(tx):
 
 
 @pytest.mark.parametrize(
-    'tx', ['T20', 'T30', 'T40', 'T50', 'T60', 'LDT', 'EDT'])
+    'tx', ['T15', 'T20', 'T30', 'T40', 'T50', 'T60', 'LDT', 'EDT'])
 def test_rt_from_edc_mulitchannel(tx):
     times = np.linspace(0, 1.5, 2**9)
     Ts = np.array([1, 2, 1.5])
@@ -38,7 +38,7 @@ def test_rt_from_edc_mulitchannel(tx):
 
 
 @pytest.mark.parametrize(
-    'tx', ['T20', 'T30', 'T40', 'T50', 'T60', 'LDT', 'EDT'])
+    'tx', ['T15', 'T20', 'T30', 'T40', 'T50', 'T60', 'LDT', 'EDT'])
 def test_rt_from_edc_mulitchannel_amplitude(tx):
     times = np.linspace(0, 5/2, 2**9)
     Ts = np.array([[1, 2, 1.5], [3, 4, 5]])


### PR DESCRIPTION
currently T15 is not supported but it is recommended to use by ISO 17497-1 (scattering coefficients measurements)

### Changes proposed in this pull request:

- add T15 as an option to ``reverberation_time_linear_regression``
- add T15 in testing

should we also fix the docstring here? seems like its not fitting anymore? or sep PR
maybe we can release it in 0.4.1 as a patch