### PR TITLE
hot: replace internal use of deprecations by pyfar suggestions

### DIFF
--- a/pyrato/dsp.py
+++ b/pyrato/dsp.py
@@ -328,7 +328,7 @@ def filter_fractional_octave_bands(
         DeprecationWarning)
 
     return pf.dsp.filter.fractional_octave_bands(
-        signal, num_fractions, freq_range=freq_range, order=order)
+        signal, num_fractions, frequency_range=freq_range, order=order)
 
 
 def estimate_noise_energy(
@@ -485,7 +485,7 @@ def preprocess_rir(
     n_channels = np.prod(data.cshape)
 
     if shift:
-        rir_start_idx = find_impulse_response_start(data)
+        rir_start_idx = pf.dsp.find_impulse_response_start(data)
 
         if channel_independent and not n_channels == 1:
             shift_samples = -rir_start_idx


### PR DESCRIPTION
### Which issue(s) are closed by this pull request?

contributes to #53

### Changes proposed in this pull request:

- ``pyrato.fractional_octave_bands`` was deprecated in favour of the pyfar version, other methods were still calling the pyrato version indead of the pyfar version.
- same for ``find_impulse_response_start``
-
