### PR TITLE
hot: fix numpy deprecation warning

### DIFF
--- a/pyrato/edc.py
+++ b/pyrato/edc.py
@@ -930,12 +930,12 @@ def intersection_time_lundeby(
         # (5) NEW LOCAL TIME INTERVAL LENGTH
         n_blocks_in_decay = (np.diff(
             10*np.log10(np.take(
-                time_window_data_current_channel, [start_idx, stop_idx])))
+                time_window_data_current_channel, [start_idx, stop_idx])))[0]
             / -10 * n_intervals_per_10dB)
 
         n_samples_per_block = np.round(np.diff(np.take(
             time_vector_window,
-            [start_idx, stop_idx])) / n_blocks_in_decay * sampling_rate)
+            [start_idx, stop_idx]))[0] / n_blocks_in_decay * sampling_rate)
 
         window_time = n_samples_per_block/sampling_rate
 


### PR DESCRIPTION
### Which issue(s) are closed by this pull request?

contributes to #53 

### Changes proposed in this pull request:

- these arrays of shape (1, ) are later on casted into a int, this results in a numpy Warning:
```
DeprecationWarning: Conversion of an array with ndim > 0 to a scalar is deprecated, and will error in future. Ensure you extract a single element from your array before perfor...
```
- this Warning is fixes by indexing it with zero, becuase this arrays have always a shape of (1, ) its fine
