### PR TITLE
fix docstring return type: energy_decay_curve_chu() function.

### DIFF
--- a/pyrato/edc.py
+++ b/pyrato/edc.py
@@ -508,7 +508,7 @@ def energy_decay_curve_chu(
 
     Returns
     -------
-    energy_decay_curve: ndarray, double
+    pyfar.TimeData
         Returns the noise handeled edc.
 
     References


### PR DESCRIPTION
### Which issue(s) are closed by this pull request?

Closes #76 

### Changes proposed in this pull request:

- docstring return typa description changed to pf.TimeData as it's done in code.
-
-
