### PR TITLE
Add a copy button to code blocks in the documentation

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -31,6 +31,7 @@ extensions = [
     'sphinx_favicon',
     'sphinx_reredirects',
     'sphinx_mdinclude',
+    'sphinx_copybutton',
 ]
 
 # show tocs for classes and functions of modules using the autodocsumm

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,6 +56,7 @@ docs = [
     "sphinx-design",
     "sphinx-favicon",
     "sphinx-reredirects",
+    "sphinx-copybutton"
 ]
 dev = ["pyrato[deploy,tests,docs]"]
 


### PR DESCRIPTION
### Changes proposed in this pull request:

- Automatically add a copybutton to each code cell in the documentation
- Configured through the sphinx-copybutton package
